### PR TITLE
fix(linter): quote all error descriptions in rustfmt

### DIFF
--- a/lintrunner_adapters/adapters/rustfmt_linter.py
+++ b/lintrunner_adapters/adapters/rustfmt_linter.py
@@ -86,7 +86,7 @@ def check_file(
             if match:
                 line = int(match["line"])
                 char = int(match["column"])
-                description = strip_path_from_error(description)
+                description = f"```\n{strip_path_from_error(description)}\n```"
             return [
                 LintMessage(
                     path=filename,


### PR DESCRIPTION
<img width="638" alt="image" src="https://user-images.githubusercontent.com/11205048/216857252-3f39a3de-5dfc-4ea8-b214-e3c23397d02d.png">
