### PR TITLE
fix: ruff-fix display all lint errors; enable ruff and format all files

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -318,3 +318,30 @@ init_command = [
     '--dry-run={{DRYRUN}}',
     'refurb==1.10.0;python_version>="3.10"',
 ]
+
+[[linter]]
+code = 'RUFF'
+include_patterns = [
+    'lintrunner_adapters/**/*.py',
+    'lintrunner_adapters/**/*.pyi',
+]
+exclude_patterns = []
+command = [
+    'python',
+    '-m',
+    'lintrunner_adapters',
+    'run',
+    'ruff_linter',
+    '--config=pyproject.toml',
+    '--explain',
+    '@{{PATHSFILE}}'
+]
+init_command = [
+    'python',
+    '-m',
+    'lintrunner_adapters',
+    'run',
+    'pip_init',
+    '--dry-run={{DRYRUN}}',
+    'ruff==0.0.241',
+]

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -333,7 +333,32 @@ command = [
     'run',
     'ruff_linter',
     '--config=pyproject.toml',
-    '--explain',
+    '@{{PATHSFILE}}'
+]
+init_command = [
+    'python',
+    '-m',
+    'lintrunner_adapters',
+    'run',
+    'pip_init',
+    '--dry-run={{DRYRUN}}',
+    'ruff==0.0.241',
+]
+
+[[linter]]
+code = 'RUFF-FIX'
+include_patterns = [
+    'lintrunner_adapters/**/*.py',
+    'lintrunner_adapters/**/*.pyi',
+]
+exclude_patterns = []
+command = [
+    'python',
+    '-m',
+    'lintrunner_adapters',
+    'run',
+    'ruff_fix_linter',
+    '--config=pyproject.toml',
     '@{{PATHSFILE}}'
 ]
 init_command = [

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -370,3 +370,4 @@ init_command = [
     '--dry-run={{DRYRUN}}',
     'ruff==0.0.241',
 ]
+is_formatter = true

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Adapters and tools for [lintrunner](https://github.com/suo/lintrunner).
 
-`lintrunner-adapters` currently supports popular Python and Rust linters and formatters like `flake8`, `pylint`, `mypy`, `black`, `rustfmt`, `clippy` and many more - and the list is growing. Contribution is welcome!
+`lintrunner-adapters` currently supports popular Python and Rust linters and formatters like `flake8`, `pylint`, `mypy`, `black`, `ruff`(with auto-fix support), `rustfmt`, `clippy` and many more - and the list is growing. Contribution is welcome!
 
 To see the list of supported linters and formatters, run `lintrunner_adapters run`.
 

--- a/examples/adapters/ruff_fix_linter/.lintrunner.toml
+++ b/examples/adapters/ruff_fix_linter/.lintrunner.toml
@@ -1,0 +1,26 @@
+[[linter]]
+code = 'RUFF-FIX'
+include_patterns = [
+    '**/*.py',
+    '**/*.pyi',
+]
+exclude_patterns = []
+command = [
+    'python',
+    '-m',
+    'lintrunner_adapters',
+    'run',
+    'ruff_fix_linter',
+    '--config=pyproject.toml',
+    '@{{PATHSFILE}}'
+]
+init_command = [
+    'python',
+    '-m',
+    'lintrunner_adapters',
+    'run',
+    'pip_init',
+    '--dry-run={{DRYRUN}}',
+    'ruff==0.0.241',
+]
+is_formatter = true

--- a/lintrunner_adapters/adapters/flake8_linter.py
+++ b/lintrunner_adapters/adapters/flake8_linter.py
@@ -198,15 +198,19 @@ def check_files(
 ) -> list[LintMessage]:
     try:
         proc = run_command(
-            [sys.executable, "-mflake8", "--exit-zero"]
-            + ([f"--config={config}"] if config else [])
-            + ([f"--append-config={append_config}"] if append_config else [])
-            + (
-                ["--docstring-convention", docstring_convention]
-                if docstring_convention
-                else []
-            )
-            + filenames,
+            [
+                sys.executable,
+                "-mflake8",
+                "--exit-zero",
+                *([f"--config={config}"] if config else []),
+                *([f"--append-config={append_config}"] if append_config else []),
+                *(
+                    ["--docstring-convention", docstring_convention]
+                    if docstring_convention
+                    else []
+                ),
+                *filenames,
+            ],
             retries=retries,
         )
     except (OSError, subprocess.CalledProcessError) as err:

--- a/lintrunner_adapters/adapters/mypy_linter.py
+++ b/lintrunner_adapters/adapters/mypy_linter.py
@@ -76,7 +76,7 @@ def check_files(
 ) -> list[LintMessage]:
     try:
         proc = run_command(
-            [sys.executable, "-mmypy", f"--config={config}"] + filenames,
+            [sys.executable, "-mmypy", f"--config={config}", *filenames],
             retries=retries,
         )
     except OSError as err:

--- a/lintrunner_adapters/adapters/pylint_linter.py
+++ b/lintrunner_adapters/adapters/pylint_linter.py
@@ -105,10 +105,14 @@ def check_files(
 ) -> list[LintMessage]:
     try:
         proc = run_command(
-            [sys.executable, "-mpylint", "--score=n"]
-            + ([f"--rcfile={rcfile}"] if rcfile else [])
-            + [f"--jobs={jobs}"]
-            + filenames,
+            [
+                sys.executable,
+                "-mpylint",
+                "--score=n",
+                *([f"--rcfile={rcfile}"] if rcfile else []),
+                f"--jobs={jobs}",
+                *filenames,
+            ],
             retries=retries,
         )
     except OSError as err:

--- a/lintrunner_adapters/adapters/refurb_linter.py
+++ b/lintrunner_adapters/adapters/refurb_linter.py
@@ -70,7 +70,7 @@ def check_files(
 ) -> list[LintMessage]:
     try:
         proc = run_command(
-            [sys.executable, "-mrefurb", "--config-file", config_file] + filenames,
+            [sys.executable, "-mrefurb", "--config-file", config_file, *filenames],
             retries=retries,
         )
     except OSError as err:

--- a/lintrunner_adapters/adapters/refurb_linter.py
+++ b/lintrunner_adapters/adapters/refurb_linter.py
@@ -70,7 +70,7 @@ def check_files(
 ) -> list[LintMessage]:
     try:
         proc = run_command(
-            [sys.executable, "-mrefurb", "--config-file", config_file, *filenames],
+            [sys.executable, "-mrefurb", "--config-file", config_file] + filenames,
             retries=retries,
         )
     except OSError as err:

--- a/lintrunner_adapters/adapters/ruff_fix_linter.py
+++ b/lintrunner_adapters/adapters/ruff_fix_linter.py
@@ -23,7 +23,7 @@ LINTER_CODE = "RUFF-FIX"
 
 def explain_rule(code: str) -> str:
     proc = run_command(
-        [sys.executable, "-mruff", "rule", "--format=json", code],
+        ["ruff", "rule", "--format=json", code],
         check=True,
     )
     rule = json.loads(str(proc.stdout, "utf-8").strip())
@@ -86,8 +86,7 @@ def check_file(
         with open(filename, "rb") as f:
             proc_fix = run_command(
                 [
-                    sys.executable,
-                    "-mruff",
+                    "ruff",
                     "--fix-only",
                     "--exit-zero",
                     *([f"--config={config}"] if config else []),
@@ -103,8 +102,7 @@ def check_file(
         with open(filename, "rb") as f:
             proc_lint = run_command(
                 [
-                    sys.executable,
-                    "-mruff",
+                    "ruff",
                     "--exit-zero",
                     "--quiet",
                     "--format=json",
@@ -187,7 +185,7 @@ def check_file(
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description=f"ruff wrapper linter. Linter code: {LINTER_CODE}",
+        description=f"ruff wrapper linter with autofix. Linter code: {LINTER_CODE}",
         fromfile_prefix_chars="@",
     )
     parser.add_argument(

--- a/lintrunner_adapters/adapters/ruff_fix_linter.py
+++ b/lintrunner_adapters/adapters/ruff_fix_linter.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import concurrent.futures
-import json
 import logging
 import os
 import subprocess

--- a/lintrunner_adapters/adapters/ruff_fix_linter.py
+++ b/lintrunner_adapters/adapters/ruff_fix_linter.py
@@ -21,15 +21,6 @@ from lintrunner_adapters import (
 LINTER_CODE = "RUFF-FIX"
 
 
-def explain_rule(code: str) -> str:
-    proc = run_command(
-        ["ruff", "rule", "--format=json", code],
-        check=True,
-    )
-    rule = json.loads(str(proc.stdout, "utf-8").strip())
-    return f"\n{rule['linter']}: {rule['summary']}"
-
-
 def check_file(
     filename: str,
     *,

--- a/lintrunner_adapters/adapters/ruff_fix_linter.py
+++ b/lintrunner_adapters/adapters/ruff_fix_linter.py
@@ -47,13 +47,13 @@ def check_file(
                 [
                     sys.executable,
                     "-mruff",
-                    "--fix",
-                    "-e",
+                    "--fix-only",
+                    "--exit-zero",
+                    *([f"--config={config}"] if config else []),
                     "--stdin-filename",
                     filename,
                     "-",
-                ]
-                + ([f"--config={config}"] if config else []),
+                ],
                 stdin=f,
                 retries=retries,
                 timeout=timeout,

--- a/lintrunner_adapters/adapters/ruff_fix_linter.py
+++ b/lintrunner_adapters/adapters/ruff_fix_linter.py
@@ -64,14 +64,16 @@ def check_file(
                 [
                     sys.executable,
                     "-mruff",
-                    "-e",
-                    "-q",
+                    "--exit-zero",
+                    "--quiet",
                     "--format=json",
+                ]
+                + ([f"--config={config}"] if config else [])
+                + [
                     "--stdin-filename",
                     filename,
                     "-",
-                ]
-                + ([f"--config={config}"] if config else []),
+                ],
                 stdin=f,
                 retries=retries,
                 timeout=timeout,

--- a/lintrunner_adapters/adapters/ruff_fix_linter.py
+++ b/lintrunner_adapters/adapters/ruff_fix_linter.py
@@ -67,9 +67,7 @@ def check_file(
                     "--exit-zero",
                     "--quiet",
                     "--format=json",
-                ]
-                + ([f"--config={config}"] if config else [])
-                + [
+                    *([f"--config={config}"] if config else []),
                     "--stdin-filename",
                     filename,
                     "-",

--- a/lintrunner_adapters/adapters/ruff_fix_linter.py
+++ b/lintrunner_adapters/adapters/ruff_fix_linter.py
@@ -30,6 +30,47 @@ def explain_rule(code: str) -> str:
     return f"\n{rule['linter']}: {rule['summary']}"
 
 
+def get_issue_severity(code: str) -> LintSeverity:
+    # "B901": `return x` inside a generator
+    # "B902": Invalid first argument to a method
+    # "B903": __slots__ efficiency
+    # "B950": Line too long
+    # "C4": Flake8 Comprehensions
+    # "C9": Cyclomatic complexity
+    # "E2": PEP8 horizontal whitespace "errors"
+    # "E3": PEP8 blank line "errors"
+    # "E5": PEP8 line length "errors"
+    # "T400": type checking Notes
+    # "T49": internal type checker errors or unmatched messages
+    if any(
+        code.startswith(x)
+        for x in (
+            "B9",
+            "C4",
+            "C9",
+            "E2",
+            "E3",
+            "E5",
+            "T400",
+            "T49",
+        )
+    ):
+        return LintSeverity.ADVICE
+
+    # "F821": Undefined name
+    # "E999": syntax error
+    if any(code.startswith(x) for x in ("F821", "E999")):
+        return LintSeverity.ERROR
+
+    # "F": PyFlakes Error
+    # "B": flake8-bugbear Error
+    # "E": PEP8 "Error"
+    # "W": PEP8 Warning
+    # possibly other plugins...
+    return LintSeverity.WARNING
+
+
+
 def check_file(
     filename: str,
     severities: dict[str, LintSeverity],
@@ -135,7 +176,7 @@ def check_file(
                 line=int(vuln["location"]["row"]),
                 char=int(vuln["location"]["column"]),
                 code=LINTER_CODE,
-                severity=severities.get(vuln["code"], LintSeverity.WARNING),
+                severity=severities.get(vuln["code"], get_issue_severity(vuln["code"])),
                 original=None,
                 replacement=None,
             )

--- a/lintrunner_adapters/adapters/ruff_fix_linter.py
+++ b/lintrunner_adapters/adapters/ruff_fix_linter.py
@@ -132,7 +132,7 @@ def check_file(
                 line=int(vuln["location"]["row"]),
                 char=int(vuln["location"]["column"]),
                 code=LINTER_CODE,
-                severity=severities.get(vuln["code"], LintSeverity.ADVICE),
+                severity=severities.get(vuln["code"], LintSeverity.WARNING),
                 original=None,
                 replacement=None,
             )

--- a/lintrunner_adapters/adapters/ruff_linter.py
+++ b/lintrunner_adapters/adapters/ruff_linter.py
@@ -87,7 +87,7 @@ def check_files(
             line=int(vuln["location"]["row"]),
             char=int(vuln["location"]["column"]),
             code=LINTER_CODE,
-            severity=severities.get(vuln["code"], LintSeverity.ADVICE),
+            severity=severities.get(vuln["code"], LintSeverity.WARNING),
             original=None,
             replacement=None,
         )

--- a/lintrunner_adapters/adapters/ruff_linter.py
+++ b/lintrunner_adapters/adapters/ruff_linter.py
@@ -128,9 +128,11 @@ def check_files(
         LintMessage(
             path=vuln["filename"],
             name=vuln["code"],
-            description=(vuln["message"]
-            if not rules
-            else f"{vuln['message']}\n{rules[vuln['code']]}"),
+            description=(
+                vuln["message"]
+                if not rules
+                else f"{vuln['message']}\n{rules[vuln['code']]}"
+            ),
             line=int(vuln["location"]["row"]),
             char=int(vuln["location"]["column"]),
             code=LINTER_CODE,

--- a/lintrunner_adapters/adapters/ruff_linter.py
+++ b/lintrunner_adapters/adapters/ruff_linter.py
@@ -51,13 +51,15 @@ def get_issue_severity(code: str) -> LintSeverity:
             "E5",
             "T400",
             "T49",
+            "PLC",
+            "PLR",
         )
     ):
         return LintSeverity.ADVICE
 
     # "F821": Undefined name
     # "E999": syntax error
-    if any(code.startswith(x) for x in ("F821", "E999")):
+    if any(code.startswith(x) for x in ("F821", "E999", "PLE")):
         return LintSeverity.ERROR
 
     # "F": PyFlakes Error
@@ -142,7 +144,7 @@ def check_files(
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description=f"ruff wrapper linter. Linter code: {LINTER_CODE}",
+        description=f"Ruff linter. Linter code: {LINTER_CODE}. Use with RUFF-FIX to auto-fix issues.",
         fromfile_prefix_chars="@",
     )
     parser.add_argument(

--- a/lintrunner_adapters/adapters/ruff_linter.py
+++ b/lintrunner_adapters/adapters/ruff_linter.py
@@ -39,9 +39,15 @@ def check_files(
 ) -> list[LintMessage]:
     try:
         proc = run_command(
-            [sys.executable, "-mruff", "-e", "-q", "--format=json"]
-            + ([f"--config={config}"] if config else [])
-            + filenames,
+            [
+                sys.executable,
+                "-mruff",
+                "--exit-zero",
+                "--quiet",
+                "--format=json",
+                *([f"--config={config}"] if config else []),
+                *filenames,
+            ],
             retries=retries,
             timeout=timeout,
             check=True,

--- a/lintrunner_adapters/adapters/ruff_linter.py
+++ b/lintrunner_adapters/adapters/ruff_linter.py
@@ -21,7 +21,7 @@ LINTER_CODE = "RUFF"
 
 def explain_rule(code: str) -> str:
     proc = run_command(
-        [sys.executable, "-mruff", "rule", "--format=json", code],
+        ["ruff", "rule", "--format=json", code],
         check=True,
     )
     rule = json.loads(str(proc.stdout, "utf-8").strip())
@@ -80,8 +80,7 @@ def check_files(
     try:
         proc = run_command(
             [
-                sys.executable,
-                "-mruff",
+                "ruff",
                 "--exit-zero",
                 "--quiet",
                 "--format=json",

--- a/lintrunner_adapters/adapters/rustfmt_linter.py
+++ b/lintrunner_adapters/adapters/rustfmt_linter.py
@@ -58,7 +58,7 @@ def check_file(
 ) -> list[LintMessage]:
     try:
         with open(filename, "rb") as f:
-            original = f.read()
+            original = pathlib.Path(filename).read_bytes()
         with open(filename, "rb") as f:
             proc = run_command(
                 [

--- a/lintrunner_adapters/adapters/rustfmt_linter.py
+++ b/lintrunner_adapters/adapters/rustfmt_linter.py
@@ -58,7 +58,7 @@ def check_file(
 ) -> list[LintMessage]:
     try:
         with open(filename, "rb") as f:
-            original = pathlib.Path(filename).read_bytes()
+            original = f.read()
         with open(filename, "rb") as f:
             proc = run_command(
                 [

--- a/lintrunner_adapters/adapters/shellcheck_linter.py
+++ b/lintrunner_adapters/adapters/shellcheck_linter.py
@@ -17,7 +17,7 @@ def check_files(
 ) -> list[LintMessage]:
     try:
         proc = run_command(
-            ["shellcheck", "--external-sources", "--format=json1"] + files
+            ["shellcheck", "--external-sources", "--format=json1", *files]
         )
     except OSError as err:
         return [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ python_version = "3.7"
 disable = ["FURB101", "FURB150"] # disable suggestions using pathlib
 
 [tool.ruff]
+target-version = "py37"
 select = [
     "D",
     "E",
@@ -89,8 +90,9 @@ select = [
     "UP",
     "YTT",
     "SIM",
-    "PL",
-    "PLR",
+    "PLE",
+    "PLC",
+    "PLW",
     "RUF",
 ]
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,3 +77,34 @@ disable = [
 [tool.refurb]
 python_version = "3.7"
 disable = ["FURB101", "FURB150"] # disable suggestions using pathlib
+
+[tool.ruff]
+select = [
+    "D",
+    "E",
+    "F",
+    "W",
+    "B",
+    "N",
+    "UP",
+    "YTT",
+    "SIM",
+    "PL",
+    "PLR",
+    "RUF",
+]
+ignore = [
+    "D1",
+    "D202",
+    "D205",
+    "D212",
+    "D400",
+    "D401",
+    "D415",
+    "E501",
+    "PLR2004",
+]
+line-length = 120
+
+[tool.ruff.pydocstyle]
+convention = "google"


### PR DESCRIPTION
Update ruff-fix to fix errors only, so that it runs faster and can be used in combination with RUFF. Set ruff default error level to warning.

RUFF-FIX is still much faster than flake8 (~400ms vs 4.6s), which I am happy about.

cc @q0w 