### PR TITLE
fix(linter)!: Use `--output-format` in the RUFF linter

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -344,7 +344,7 @@ init_command = [
     'run',
     'pip_init',
     '--dry-run={{DRYRUN}}',
-    'ruff==0.0.262',
+    'ruff==0.0.291',
 ]
 is_formatter = true
 

--- a/lintrunner_adapters/adapters/ruff_linter.py
+++ b/lintrunner_adapters/adapters/ruff_linter.py
@@ -101,7 +101,7 @@ def check_files(
                 "ruff",
                 "--exit-zero",
                 "--quiet",
-                "--format=json",
+                "--output-format=json",
                 *([f"--config={config}"] if config else []),
                 *filenames,
             ],

--- a/lintrunner_adapters/adapters/ruff_linter.py
+++ b/lintrunner_adapters/adapters/ruff_linter.py
@@ -23,7 +23,7 @@ LINTER_CODE = "RUFF"
 
 def explain_rule(code: str) -> str:
     proc = run_command(
-        ["ruff", "rule", "--format=json", code],
+        ["ruff", "rule", "--output-format=json", code],
         check=True,
     )
     rule = json.loads(str(proc.stdout, "utf-8").strip())
@@ -238,7 +238,7 @@ def check_file_for_fixes(
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description=f"Ruff linter. Linter code: {LINTER_CODE}. Use with RUFF-FIX to auto-fix issues.",
+        description=f"Ruff linter with auto-fix support. Linter code: {LINTER_CODE}.",
         fromfile_prefix_chars="@",
     )
     parser.add_argument(

--- a/lintrunner_adapters/adapters/ruff_linter.py
+++ b/lintrunner_adapters/adapters/ruff_linter.py
@@ -23,7 +23,7 @@ LINTER_CODE = "RUFF"
 
 def explain_rule(code: str) -> str:
     proc = run_command(
-        ["ruff", "rule", "--output-format=json", code],
+        ["ruff", "rule", "--format=json", code],
         check=True,
     )
     rule = json.loads(str(proc.stdout, "utf-8").strip())

--- a/lintrunner_adapters/adapters/rustfmt_linter.py
+++ b/lintrunner_adapters/adapters/rustfmt_linter.py
@@ -147,8 +147,8 @@ def check_file(
                 replacement=None,
                 description=(
                     "Possible rustfmt bug. "
-                    "rustfmt returned error output but didn't fail:\n{}"
-                ).format(clean_err),
+                    f"rustfmt returned error output but didn't fail:\n{clean_err}"
+                ),
             )
         ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ warn_unused_ignores = false
 
 [tool.poetry]
 name = "lintrunner-adapters"
-version = "0.9.0"
+version = "0.10.0"
 description = "Adapters and tools for lintrunner"
 authors = ["Justin Chu <justinchu@microsoft.com>"]
 license = "MIT"


### PR DESCRIPTION
The `--format` option has been renamed to `--output-format` in https://github.com/astral-sh/ruff/pull/7984

This is a breaking change and we require ruff>=0.0.291 to be compatible.