### PR TITLE
fix(linter): resolve file path for the black linter to avoid a bug in black file path handling

### DIFF
--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -166,7 +166,7 @@ init_command = [
     'run',
     'pip_init',
     '--dry-run={{DRYRUN}}',
-    'black==24.1.1',
+    'black==23.12.1',  # Use 24.x when ruff styles are updated
     'isort==5.10.1',
 ]
 is_formatter = true

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -166,7 +166,7 @@ init_command = [
     'run',
     'pip_init',
     '--dry-run={{DRYRUN}}',
-    'black==23.12.1',  # Use 24.x when ruff styles are updated
+    'black==23.12.1', # Use 24.x when ruff styles are updated
     'isort==5.10.1',
 ]
 is_formatter = true

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -166,7 +166,7 @@ init_command = [
     'run',
     'pip_init',
     '--dry-run={{DRYRUN}}',
-    'black==22.10.0',
+    'black==24.1.1',
     'isort==5.10.1',
 ]
 is_formatter = true

--- a/.lintrunner.toml
+++ b/.lintrunner.toml
@@ -346,7 +346,7 @@ init_command = [
     'run',
     'pip_init',
     '--dry-run={{DRYRUN}}',
-    'ruff==0.1.5',
+    'ruff==0.2.1',
 ]
 is_formatter = true
 
@@ -373,7 +373,7 @@ init_command = [
     'run',
     'pip_init',
     '--dry-run={{DRYRUN}}',
-    'ruff==0.1.5',
+    'ruff==0.2.1',
 ]
 is_formatter = true
 

--- a/examples/pytorch/black_isort_linter.py
+++ b/examples/pytorch/black_isort_linter.py
@@ -225,11 +225,11 @@ def main() -> None:
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
-        level=logging.NOTSET
-        if args.verbose
-        else logging.DEBUG
-        if len(args.filenames) < 1000
-        else logging.INFO,
+        level=(
+            logging.NOTSET
+            if args.verbose
+            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+        ),
         stream=sys.stderr,
     )
 

--- a/examples/pytorch/black_isort_linter.py
+++ b/examples/pytorch/black_isort_linter.py
@@ -228,7 +228,9 @@ def main() -> None:
         level=(
             logging.NOTSET
             if args.verbose
-            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+            else logging.DEBUG
+            if len(args.filenames) < 1000
+            else logging.INFO
         ),
         stream=sys.stderr,
     )

--- a/examples/pytorch/black_isort_linter.py
+++ b/examples/pytorch/black_isort_linter.py
@@ -115,7 +115,7 @@ def check_file(
         with open(filename, "rb") as f:
             # Resolve the file path to get around errors with Python 3.8/3.9
             # https://github.com/psf/black/issues/4209
-            filename = os.path.realpath(filename)
+            filename = str(pathlib.Path(filename).resolve())
             proc = run_command(
                 [sys.executable, "-mblack", "--stdin-filename", filename, "-"],
                 stdin=f,

--- a/examples/pytorch/black_isort_linter.py
+++ b/examples/pytorch/black_isort_linter.py
@@ -113,6 +113,9 @@ def check_file(
         with open(filename, "rb") as f:
             original = f.read()
         with open(filename, "rb") as f:
+            # Resolve the file path to get around errors with Python 3.8/3.9
+            # https://github.com/psf/black/issues/4209
+            filename = os.path.realpath(filename)
             proc = run_command(
                 [sys.executable, "-mblack", "--stdin-filename", filename, "-"],
                 stdin=f,

--- a/examples/pytorch/black_isort_linter.py
+++ b/examples/pytorch/black_isort_linter.py
@@ -113,9 +113,6 @@ def check_file(
         with open(filename, "rb") as f:
             original = f.read()
         with open(filename, "rb") as f:
-            # Resolve the file path to get around errors with Python 3.8/3.9
-            # https://github.com/psf/black/issues/4209
-            filename = str(pathlib.Path(filename).resolve())
             proc = run_command(
                 [sys.executable, "-mblack", "--stdin-filename", filename, "-"],
                 stdin=f,

--- a/examples/pytorch/black_linter.py
+++ b/examples/pytorch/black_linter.py
@@ -200,11 +200,11 @@ def main() -> None:
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
-        level=logging.NOTSET
-        if args.verbose
-        else logging.DEBUG
-        if len(args.filenames) < 1000
-        else logging.INFO,
+        level=(
+            logging.NOTSET
+            if args.verbose
+            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+        ),
         stream=sys.stderr,
     )
 

--- a/examples/pytorch/black_linter.py
+++ b/examples/pytorch/black_linter.py
@@ -203,7 +203,9 @@ def main() -> None:
         level=(
             logging.NOTSET
             if args.verbose
-            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+            else logging.DEBUG
+            if len(args.filenames) < 1000
+            else logging.INFO
         ),
         stream=sys.stderr,
     )

--- a/examples/pytorch/clangformat_linter.py
+++ b/examples/pytorch/clangformat_linter.py
@@ -202,11 +202,11 @@ def main() -> None:
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
-        level=logging.NOTSET
-        if args.verbose
-        else logging.DEBUG
-        if len(args.filenames) < 1000
-        else logging.INFO,
+        level=(
+            logging.NOTSET
+            if args.verbose
+            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+        ),
         stream=sys.stderr,
     )
 

--- a/examples/pytorch/clangformat_linter.py
+++ b/examples/pytorch/clangformat_linter.py
@@ -205,7 +205,9 @@ def main() -> None:
         level=(
             logging.NOTSET
             if args.verbose
-            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+            else logging.DEBUG
+            if len(args.filenames) < 1000
+            else logging.INFO
         ),
         stream=sys.stderr,
     )

--- a/examples/pytorch/clangtidy_linter.py
+++ b/examples/pytorch/clangtidy_linter.py
@@ -181,9 +181,12 @@ def check_file(
                 name=match["code"],
                 description=match["message"],
                 line=int(match["line"]),
-                char=int(match["column"])
-                if match["column"] is not None and not match["column"].startswith("-")
-                else None,
+                char=(
+                    int(match["column"])
+                    if match["column"] is not None
+                    and not match["column"].startswith("-")
+                    else None
+                ),
                 code="CLANGTIDY",
                 severity=severities.get(match["severity"], LintSeverity.ERROR),
                 original=None,
@@ -228,11 +231,11 @@ def main() -> None:
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
-        level=logging.NOTSET
-        if args.verbose
-        else logging.DEBUG
-        if len(args.filenames) < 1000
-        else logging.INFO,
+        level=(
+            logging.NOTSET
+            if args.verbose
+            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+        ),
         stream=sys.stderr,
     )
 

--- a/examples/pytorch/clangtidy_linter.py
+++ b/examples/pytorch/clangtidy_linter.py
@@ -234,7 +234,9 @@ def main() -> None:
         level=(
             logging.NOTSET
             if args.verbose
-            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+            else logging.DEBUG
+            if len(args.filenames) < 1000
+            else logging.INFO
         ),
         stream=sys.stderr,
     )

--- a/examples/pytorch/clangtidy_linter.py
+++ b/examples/pytorch/clangtidy_linter.py
@@ -234,9 +234,7 @@ def main() -> None:
         level=(
             logging.NOTSET
             if args.verbose
-            else logging.DEBUG
-            if len(args.filenames) < 1000
-            else logging.INFO
+            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
         ),
         stream=sys.stderr,
     )

--- a/examples/pytorch/exec_linter.py
+++ b/examples/pytorch/exec_linter.py
@@ -71,7 +71,9 @@ if __name__ == "__main__":
         level=(
             logging.NOTSET
             if args.verbose
-            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+            else logging.DEBUG
+            if len(args.filenames) < 1000
+            else logging.INFO
         ),
         stream=sys.stderr,
     )

--- a/examples/pytorch/exec_linter.py
+++ b/examples/pytorch/exec_linter.py
@@ -68,11 +68,11 @@ if __name__ == "__main__":
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
-        level=logging.NOTSET
-        if args.verbose
-        else logging.DEBUG
-        if len(args.filenames) < 1000
-        else logging.INFO,
+        level=(
+            logging.NOTSET
+            if args.verbose
+            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+        ),
         stream=sys.stderr,
     )
 

--- a/examples/pytorch/flake8_linter.py
+++ b/examples/pytorch/flake8_linter.py
@@ -360,7 +360,9 @@ def main() -> None:
         level=(
             logging.NOTSET
             if args.verbose
-            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+            else logging.DEBUG
+            if len(args.filenames) < 1000
+            else logging.INFO
         ),
         stream=sys.stderr,
     )

--- a/examples/pytorch/flake8_linter.py
+++ b/examples/pytorch/flake8_linter.py
@@ -264,9 +264,11 @@ def check_files(
     try:
         proc = run_command(
             [sys.executable, "-mflake8", "--exit-zero"] + filenames,
-            extra_env={"FLAKE8_PLUGINS_PATH": flake8_plugins_path}
-            if flake8_plugins_path
-            else None,
+            extra_env=(
+                {"FLAKE8_PLUGINS_PATH": flake8_plugins_path}
+                if flake8_plugins_path
+                else None
+            ),
             retries=retries,
         )
     except (OSError, subprocess.CalledProcessError) as err:
@@ -307,9 +309,11 @@ def check_files(
                 get_issue_documentation_url(match["code"]),
             ),
             line=int(match["line"]),
-            char=int(match["column"])
-            if match["column"] is not None and not match["column"].startswith("-")
-            else None,
+            char=(
+                int(match["column"])
+                if match["column"] is not None and not match["column"].startswith("-")
+                else None
+            ),
             code="FLAKE8",
             severity=severities.get(match["code"]) or get_issue_severity(match["code"]),
             original=None,
@@ -353,11 +357,11 @@ def main() -> None:
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
-        level=logging.NOTSET
-        if args.verbose
-        else logging.DEBUG
-        if len(args.filenames) < 1000
-        else logging.INFO,
+        level=(
+            logging.NOTSET
+            if args.verbose
+            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+        ),
         stream=sys.stderr,
     )
 

--- a/examples/pytorch/grep_linter.py
+++ b/examples/pytorch/grep_linter.py
@@ -212,7 +212,9 @@ def main() -> None:
         level=(
             logging.NOTSET
             if args.verbose
-            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+            else logging.DEBUG
+            if len(args.filenames) < 1000
+            else logging.INFO
         ),
         stream=sys.stderr,
     )

--- a/examples/pytorch/grep_linter.py
+++ b/examples/pytorch/grep_linter.py
@@ -209,11 +209,11 @@ def main() -> None:
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
-        level=logging.NOTSET
-        if args.verbose
-        else logging.DEBUG
-        if len(args.filenames) < 1000
-        else logging.INFO,
+        level=(
+            logging.NOTSET
+            if args.verbose
+            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+        ),
         stream=sys.stderr,
     )
 

--- a/examples/pytorch/isort_linter.py
+++ b/examples/pytorch/isort_linter.py
@@ -200,11 +200,11 @@ def main() -> None:
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
-        level=logging.NOTSET
-        if args.verbose
-        else logging.DEBUG
-        if len(args.filenames) < 1000
-        else logging.INFO,
+        level=(
+            logging.NOTSET
+            if args.verbose
+            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+        ),
         stream=sys.stderr,
     )
 

--- a/examples/pytorch/isort_linter.py
+++ b/examples/pytorch/isort_linter.py
@@ -203,7 +203,9 @@ def main() -> None:
         level=(
             logging.NOTSET
             if args.verbose
-            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+            else logging.DEBUG
+            if len(args.filenames) < 1000
+            else logging.INFO
         ),
         stream=sys.stderr,
     )

--- a/examples/pytorch/mypy_linter.py
+++ b/examples/pytorch/mypy_linter.py
@@ -116,9 +116,11 @@ def check_files(
             name=match["code"],
             description=match["message"],
             line=int(match["line"]),
-            char=int(match["column"])
-            if match["column"] is not None and not match["column"].startswith("-")
-            else None,
+            char=(
+                int(match["column"])
+                if match["column"] is not None and not match["column"].startswith("-")
+                else None
+            ),
             code="MYPY",
             severity=severities.get(match["severity"], LintSeverity.ERROR),
             original=None,
@@ -158,11 +160,11 @@ def main() -> None:
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
-        level=logging.NOTSET
-        if args.verbose
-        else logging.DEBUG
-        if len(args.filenames) < 1000
-        else logging.INFO,
+        level=(
+            logging.NOTSET
+            if args.verbose
+            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+        ),
         stream=sys.stderr,
     )
 

--- a/examples/pytorch/mypy_linter.py
+++ b/examples/pytorch/mypy_linter.py
@@ -163,7 +163,9 @@ def main() -> None:
         level=(
             logging.NOTSET
             if args.verbose
-            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+            else logging.DEBUG
+            if len(args.filenames) < 1000
+            else logging.INFO
         ),
         stream=sys.stderr,
     )

--- a/examples/pytorch/newlines_linter.py
+++ b/examples/pytorch/newlines_linter.py
@@ -145,11 +145,11 @@ if __name__ == "__main__":
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
-        level=logging.NOTSET
-        if args.verbose
-        else logging.DEBUG
-        if len(args.filenames) < 1000
-        else logging.INFO,
+        level=(
+            logging.NOTSET
+            if args.verbose
+            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+        ),
         stream=sys.stderr,
     )
 

--- a/examples/pytorch/newlines_linter.py
+++ b/examples/pytorch/newlines_linter.py
@@ -148,7 +148,9 @@ if __name__ == "__main__":
         level=(
             logging.NOTSET
             if args.verbose
-            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+            else logging.DEBUG
+            if len(args.filenames) < 1000
+            else logging.INFO
         ),
         stream=sys.stderr,
     )

--- a/examples/pytorch/s3_init.py
+++ b/examples/pytorch/s3_init.py
@@ -189,9 +189,11 @@ if __name__ == "__main__":
         DRY_RUN = True
 
     logging.basicConfig(
-        format="[DRY_RUN] %(levelname)s: %(message)s"
-        if DRY_RUN
-        else "%(levelname)s: %(message)s",
+        format=(
+            "[DRY_RUN] %(levelname)s: %(message)s"
+            if DRY_RUN
+            else "%(levelname)s: %(message)s"
+        ),
         level=logging.INFO,
         stream=sys.stderr,
     )

--- a/examples/pytorch/ufmt_linter.py
+++ b/examples/pytorch/ufmt_linter.py
@@ -119,7 +119,9 @@ def main() -> None:
         level=(
             logging.NOTSET
             if args.verbose
-            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+            else logging.DEBUG
+            if len(args.filenames) < 1000
+            else logging.INFO
         ),
         stream=sys.stderr,
     )

--- a/examples/pytorch/ufmt_linter.py
+++ b/examples/pytorch/ufmt_linter.py
@@ -116,11 +116,11 @@ def main() -> None:
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
-        level=logging.NOTSET
-        if args.verbose
-        else logging.DEBUG
-        if len(args.filenames) < 1000
-        else logging.INFO,
+        level=(
+            logging.NOTSET
+            if args.verbose
+            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+        ),
         stream=sys.stderr,
     )
 

--- a/lintrunner_adapters/__init__.py
+++ b/lintrunner_adapters/__init__.py
@@ -1,4 +1,5 @@
 """Adapters and tools for lintrunner."""
+
 from __future__ import annotations
 
 __all__ = [

--- a/lintrunner_adapters/__main__.py
+++ b/lintrunner_adapters/__main__.py
@@ -10,6 +10,7 @@ Use
 
 to list available adapters.
 """
+
 from __future__ import annotations
 
 import json

--- a/lintrunner_adapters/adapters/add_trailing_comma_linter.py
+++ b/lintrunner_adapters/adapters/add_trailing_comma_linter.py
@@ -117,7 +117,9 @@ def main() -> None:
         level=(
             logging.NOTSET
             if args.verbose
-            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+            else logging.DEBUG
+            if len(args.filenames) < 1000
+            else logging.INFO
         ),
         stream=sys.stderr,
     )

--- a/lintrunner_adapters/adapters/add_trailing_comma_linter.py
+++ b/lintrunner_adapters/adapters/add_trailing_comma_linter.py
@@ -114,11 +114,11 @@ def main() -> None:
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
-        level=logging.NOTSET
-        if args.verbose
-        else logging.DEBUG
-        if len(args.filenames) < 1000
-        else logging.INFO,
+        level=(
+            logging.NOTSET
+            if args.verbose
+            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+        ),
         stream=sys.stderr,
     )
 

--- a/lintrunner_adapters/adapters/black_isort_linter.py
+++ b/lintrunner_adapters/adapters/black_isort_linter.py
@@ -144,11 +144,11 @@ def main() -> None:
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
-        level=logging.NOTSET
-        if args.verbose
-        else logging.DEBUG
-        if len(args.filenames) < 1000
-        else logging.INFO,
+        level=(
+            logging.NOTSET
+            if args.verbose
+            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+        ),
         stream=sys.stderr,
     )
 

--- a/lintrunner_adapters/adapters/black_isort_linter.py
+++ b/lintrunner_adapters/adapters/black_isort_linter.py
@@ -37,10 +37,8 @@ def check_file(
                 timeout=timeout,
                 check=True,
             )
-            import_sorted = proc.stdout
             # Pipe isort's result to black
-            proc = run_command(
-                [
+            replacement = subprocess.check_output([
                     sys.executable,
                     "-mblack",
                     *(("--pyi",) if filename.endswith(".pyi") else ()),
@@ -50,11 +48,8 @@ def check_file(
                     filename,
                     "-",
                 ],
-                stdin=None,
-                input=import_sorted,
-                retries=retries,
+                stdin=proc.stdout,
                 timeout=timeout,
-                check=True,
             )
     except subprocess.TimeoutExpired:
         return [
@@ -103,7 +98,6 @@ def check_file(
             )
         ]
 
-    replacement = proc.stdout
     if original == replacement:
         return []
 

--- a/lintrunner_adapters/adapters/black_isort_linter.py
+++ b/lintrunner_adapters/adapters/black_isort_linter.py
@@ -8,6 +8,7 @@ import argparse
 import concurrent.futures
 import logging
 import os
+import pathlib
 import subprocess
 import sys
 
@@ -42,7 +43,7 @@ def check_file(
 
             # Resolve the file path to get around errors with Python 3.8/3.9 on Windows
             # https://github.com/psf/black/issues/4209
-            resolved_filename = os.path.realpath(filename)
+            resolved_filename = str(pathlib.Path(filename).resolve())
             proc = run_command(
                 [
                     sys.executable,

--- a/lintrunner_adapters/adapters/black_isort_linter.py
+++ b/lintrunner_adapters/adapters/black_isort_linter.py
@@ -28,9 +28,21 @@ def check_file(
         with open(filename, "rb") as f:
             original = f.read()
         with open(filename, "rb") as f:
-            # Use black first because black >24.1 sees an empty stdin with
-            # Python 3.8/3.9 running with lintrunner on Windows
-            # https://github.com/justinchuby/lintrunner-adapters/issues/93
+            # Run isort first then black so we get consistent result
+            # even if isort is not using the black profile
+            proc = run_command(
+                [sys.executable, "-misort", "-"],
+                stdin=f,
+                retries=retries,
+                timeout=timeout,
+                check=True,
+            )
+            import_sorted = proc.stdout
+            # Pipe isort's result to black
+
+            # Resolve the file path to get around errors with Python 3.8/3.9 on Windows
+            # https://github.com/psf/black/issues/4209
+            filename = os.path.realpath(filename)
             proc = run_command(
                 [
                     sys.executable,
@@ -42,19 +54,12 @@ def check_file(
                     filename,
                     "-",
                 ],
-                stdin=f,
+                stdin=None,
+                input=import_sorted,
                 retries=retries,
                 timeout=timeout,
                 check=True,
             )
-            proc = run_command(
-                [sys.executable, "-misort", "-"],
-                input=proc.stdout,
-                retries=retries,
-                timeout=timeout,
-                check=True,
-            )
-
     except subprocess.TimeoutExpired:
         return [
             LintMessage(
@@ -142,11 +147,11 @@ def main() -> None:
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
-        level=(
-            logging.NOTSET
-            if args.verbose
-            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
-        ),
+        level=logging.NOTSET
+        if args.verbose
+        else logging.DEBUG
+        if len(args.filenames) < 1000
+        else logging.INFO,
         stream=sys.stderr,
     )
 

--- a/lintrunner_adapters/adapters/black_isort_linter.py
+++ b/lintrunner_adapters/adapters/black_isort_linter.py
@@ -24,6 +24,8 @@ def check_file(
     *,
     fast: bool = False,
 ) -> list[LintMessage]:
+    del retries  # Unused
+
     try:
         with open(filename, "rb") as f:
             original = f.read()

--- a/lintrunner_adapters/adapters/black_isort_linter.py
+++ b/lintrunner_adapters/adapters/black_isort_linter.py
@@ -147,11 +147,11 @@ def main() -> None:
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
-        level=logging.NOTSET
-        if args.verbose
-        else logging.DEBUG
-        if len(args.filenames) < 1000
-        else logging.INFO,
+        level=(
+            logging.NOTSET
+            if args.verbose
+            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+        ),
         stream=sys.stderr,
     )
 

--- a/lintrunner_adapters/adapters/black_isort_linter.py
+++ b/lintrunner_adapters/adapters/black_isort_linter.py
@@ -42,7 +42,7 @@ def check_file(
 
             # Resolve the file path to get around errors with Python 3.8/3.9 on Windows
             # https://github.com/psf/black/issues/4209
-            filename = os.path.realpath(filename)
+            resolved_filename = os.path.realpath(filename)
             proc = run_command(
                 [
                     sys.executable,
@@ -51,7 +51,7 @@ def check_file(
                     *(("--ipynb",) if filename.endswith(".ipynb") else ()),
                     *(("--fast",) if fast else ()),
                     "--stdin-filename",
-                    filename,
+                    resolved_filename,
                     "-",
                 ],
                 stdin=None,

--- a/lintrunner_adapters/adapters/black_isort_linter.py
+++ b/lintrunner_adapters/adapters/black_isort_linter.py
@@ -151,7 +151,9 @@ def main() -> None:
         level=(
             logging.NOTSET
             if args.verbose
-            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+            else logging.DEBUG
+            if len(args.filenames) < 1000
+            else logging.INFO
         ),
         stream=sys.stderr,
     )

--- a/lintrunner_adapters/adapters/black_linter.py
+++ b/lintrunner_adapters/adapters/black_linter.py
@@ -129,11 +129,11 @@ def main() -> None:
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
-        level=logging.NOTSET
-        if args.verbose
-        else logging.DEBUG
-        if len(args.filenames) < 1000
-        else logging.INFO,
+        level=(
+            logging.NOTSET
+            if args.verbose
+            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+        ),
         stream=sys.stderr,
     )
 

--- a/lintrunner_adapters/adapters/black_linter.py
+++ b/lintrunner_adapters/adapters/black_linter.py
@@ -6,6 +6,7 @@ import argparse
 import concurrent.futures
 import logging
 import os
+import pathlib
 import subprocess
 import sys
 
@@ -26,6 +27,9 @@ def check_file(
         with open(filename, "rb") as f:
             original = f.read()
         with open(filename, "rb") as f:
+            # Resolve the file path to get around errors with Python 3.8/3.9 on Windows
+            # https://github.com/psf/black/issues/4209
+            resolved_filename = str(pathlib.Path(filename).resolve())
             proc = run_command(
                 [
                     sys.executable,
@@ -34,7 +38,7 @@ def check_file(
                     *(("--ipynb",) if filename.endswith(".ipynb") else ()),
                     *(("--fast",) if fast else ()),
                     "--stdin-filename",
-                    filename,
+                    resolved_filename,
                     "-",
                 ],
                 stdin=f,

--- a/lintrunner_adapters/adapters/black_linter.py
+++ b/lintrunner_adapters/adapters/black_linter.py
@@ -136,7 +136,9 @@ def main() -> None:
         level=(
             logging.NOTSET
             if args.verbose
-            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+            else logging.DEBUG
+            if len(args.filenames) < 1000
+            else logging.INFO
         ),
         stream=sys.stderr,
     )

--- a/lintrunner_adapters/adapters/clangformat_linter.py
+++ b/lintrunner_adapters/adapters/clangformat_linter.py
@@ -139,7 +139,9 @@ def main() -> None:
         level=(
             logging.NOTSET
             if args.verbose
-            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+            else logging.DEBUG
+            if len(args.filenames) < 1000
+            else logging.INFO
         ),
         stream=sys.stderr,
     )

--- a/lintrunner_adapters/adapters/clangformat_linter.py
+++ b/lintrunner_adapters/adapters/clangformat_linter.py
@@ -136,11 +136,11 @@ def main() -> None:
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
-        level=logging.NOTSET
-        if args.verbose
-        else logging.DEBUG
-        if len(args.filenames) < 1000
-        else logging.INFO,
+        level=(
+            logging.NOTSET
+            if args.verbose
+            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+        ),
         stream=sys.stderr,
     )
 

--- a/lintrunner_adapters/adapters/clippy_linter.py
+++ b/lintrunner_adapters/adapters/clippy_linter.py
@@ -222,7 +222,9 @@ def main() -> None:
         level=(
             logging.NOTSET
             if args.verbose
-            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+            else logging.DEBUG
+            if len(args.filenames) < 1000
+            else logging.INFO
         ),
         stream=sys.stderr,
     )

--- a/lintrunner_adapters/adapters/clippy_linter.py
+++ b/lintrunner_adapters/adapters/clippy_linter.py
@@ -219,11 +219,11 @@ def main() -> None:
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
-        level=logging.NOTSET
-        if args.verbose
-        else logging.DEBUG
-        if len(args.filenames) < 1000
-        else logging.INFO,
+        level=(
+            logging.NOTSET
+            if args.verbose
+            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+        ),
         stream=sys.stderr,
     )
 

--- a/lintrunner_adapters/adapters/django_upgrade_linter.py
+++ b/lintrunner_adapters/adapters/django_upgrade_linter.py
@@ -121,11 +121,11 @@ def main() -> None:
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
-        level=logging.NOTSET
-        if args.verbose
-        else logging.DEBUG
-        if len(args.filenames) < 1000
-        else logging.INFO,
+        level=(
+            logging.NOTSET
+            if args.verbose
+            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+        ),
         stream=sys.stderr,
     )
 

--- a/lintrunner_adapters/adapters/django_upgrade_linter.py
+++ b/lintrunner_adapters/adapters/django_upgrade_linter.py
@@ -124,7 +124,9 @@ def main() -> None:
         level=(
             logging.NOTSET
             if args.verbose
-            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+            else logging.DEBUG
+            if len(args.filenames) < 1000
+            else logging.INFO
         ),
         stream=sys.stderr,
     )

--- a/lintrunner_adapters/adapters/editorconfig_checker_linter.py
+++ b/lintrunner_adapters/adapters/editorconfig_checker_linter.py
@@ -99,11 +99,11 @@ def main() -> None:
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
-        level=logging.NOTSET
-        if args.verbose
-        else logging.DEBUG
-        if len(args.filenames) < 1000
-        else logging.INFO,
+        level=(
+            logging.NOTSET
+            if args.verbose
+            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+        ),
         stream=sys.stderr,
     )
 

--- a/lintrunner_adapters/adapters/editorconfig_checker_linter.py
+++ b/lintrunner_adapters/adapters/editorconfig_checker_linter.py
@@ -102,7 +102,9 @@ def main() -> None:
         level=(
             logging.NOTSET
             if args.verbose
-            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+            else logging.DEBUG
+            if len(args.filenames) < 1000
+            else logging.INFO
         ),
         stream=sys.stderr,
     )

--- a/lintrunner_adapters/adapters/exec_linter.py
+++ b/lintrunner_adapters/adapters/exec_linter.py
@@ -50,11 +50,11 @@ def main() -> None:
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
-        level=logging.NOTSET
-        if args.verbose
-        else logging.DEBUG
-        if len(args.filenames) < 1000
-        else logging.INFO,
+        level=(
+            logging.NOTSET
+            if args.verbose
+            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+        ),
         stream=sys.stderr,
     )
 

--- a/lintrunner_adapters/adapters/exec_linter.py
+++ b/lintrunner_adapters/adapters/exec_linter.py
@@ -53,7 +53,9 @@ def main() -> None:
         level=(
             logging.NOTSET
             if args.verbose
-            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+            else logging.DEBUG
+            if len(args.filenames) < 1000
+            else logging.INFO
         ),
         stream=sys.stderr,
     )

--- a/lintrunner_adapters/adapters/flake8_linter.py
+++ b/lintrunner_adapters/adapters/flake8_linter.py
@@ -308,7 +308,9 @@ def main() -> None:
         level=(
             logging.NOTSET
             if args.verbose
-            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+            else logging.DEBUG
+            if len(args.filenames) < 1000
+            else logging.INFO
         ),
         stream=sys.stderr,
     )

--- a/lintrunner_adapters/adapters/flake8_linter.py
+++ b/lintrunner_adapters/adapters/flake8_linter.py
@@ -252,9 +252,11 @@ def check_files(
                 show_disable,
             ),
             line=int(match["line"]),
-            char=int(match["column"])
-            if match["column"] is not None and not match["column"].startswith("-")
-            else None,
+            char=(
+                int(match["column"])
+                if match["column"] is not None and not match["column"].startswith("-")
+                else None
+            ),
             code=LINTER_CODE,
             severity=severities.get(match["code"]) or get_issue_severity(match["code"]),
             original=None,
@@ -303,11 +305,11 @@ def main() -> None:
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
-        level=logging.NOTSET
-        if args.verbose
-        else logging.DEBUG
-        if len(args.filenames) < 1000
-        else logging.INFO,
+        level=(
+            logging.NOTSET
+            if args.verbose
+            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+        ),
         stream=sys.stderr,
     )
 

--- a/lintrunner_adapters/adapters/grep_linter.py
+++ b/lintrunner_adapters/adapters/grep_linter.py
@@ -163,11 +163,11 @@ def main() -> None:
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
-        level=logging.NOTSET
-        if args.verbose
-        else logging.DEBUG
-        if len(args.filenames) < 1000
-        else logging.INFO,
+        level=(
+            logging.NOTSET
+            if args.verbose
+            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+        ),
         stream=sys.stderr,
     )
 

--- a/lintrunner_adapters/adapters/grep_linter.py
+++ b/lintrunner_adapters/adapters/grep_linter.py
@@ -166,7 +166,9 @@ def main() -> None:
         level=(
             logging.NOTSET
             if args.verbose
-            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+            else logging.DEBUG
+            if len(args.filenames) < 1000
+            else logging.INFO
         ),
         stream=sys.stderr,
     )

--- a/lintrunner_adapters/adapters/isort_linter.py
+++ b/lintrunner_adapters/adapters/isort_linter.py
@@ -113,11 +113,11 @@ def main() -> None:
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
-        level=logging.NOTSET
-        if args.verbose
-        else logging.DEBUG
-        if len(args.filenames) < 1000
-        else logging.INFO,
+        level=(
+            logging.NOTSET
+            if args.verbose
+            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+        ),
         stream=sys.stderr,
     )
 

--- a/lintrunner_adapters/adapters/isort_linter.py
+++ b/lintrunner_adapters/adapters/isort_linter.py
@@ -116,7 +116,9 @@ def main() -> None:
         level=(
             logging.NOTSET
             if args.verbose
-            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+            else logging.DEBUG
+            if len(args.filenames) < 1000
+            else logging.INFO
         ),
         stream=sys.stderr,
     )

--- a/lintrunner_adapters/adapters/mypy_linter.py
+++ b/lintrunner_adapters/adapters/mypy_linter.py
@@ -101,9 +101,11 @@ def check_files(
             description=match["message"]
             + (disable_message(match["code"]) if show_disable else ""),
             line=int(match["line"]),
-            char=int(match["column"])
-            if match["column"] is not None and not match["column"].startswith("-")
-            else None,
+            char=(
+                int(match["column"])
+                if match["column"] is not None and not match["column"].startswith("-")
+                else None
+            ),
             code=LINTER_CODE,
             severity=SEVERITIES.get(match["severity"], LintSeverity.ERROR),
             original=None,
@@ -138,11 +140,11 @@ def main() -> None:
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
-        level=logging.NOTSET
-        if args.verbose
-        else logging.DEBUG
-        if len(args.filenames) < 1000
-        else logging.INFO,
+        level=(
+            logging.NOTSET
+            if args.verbose
+            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+        ),
         stream=sys.stderr,
     )
 

--- a/lintrunner_adapters/adapters/mypy_linter.py
+++ b/lintrunner_adapters/adapters/mypy_linter.py
@@ -143,7 +143,9 @@ def main() -> None:
         level=(
             logging.NOTSET
             if args.verbose
-            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+            else logging.DEBUG
+            if len(args.filenames) < 1000
+            else logging.INFO
         ),
         stream=sys.stderr,
     )

--- a/lintrunner_adapters/adapters/newlines_linter.py
+++ b/lintrunner_adapters/adapters/newlines_linter.py
@@ -133,11 +133,11 @@ if __name__ == "__main__":
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
-        level=logging.NOTSET
-        if args.verbose
-        else logging.DEBUG
-        if len(args.filenames) < 1000
-        else logging.INFO,
+        level=(
+            logging.NOTSET
+            if args.verbose
+            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+        ),
         stream=sys.stderr,
     )
 

--- a/lintrunner_adapters/adapters/newlines_linter.py
+++ b/lintrunner_adapters/adapters/newlines_linter.py
@@ -136,7 +136,9 @@ if __name__ == "__main__":
         level=(
             logging.NOTSET
             if args.verbose
-            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+            else logging.DEBUG
+            if len(args.filenames) < 1000
+            else logging.INFO
         ),
         stream=sys.stderr,
     )

--- a/lintrunner_adapters/adapters/pylint_linter.py
+++ b/lintrunner_adapters/adapters/pylint_linter.py
@@ -203,7 +203,9 @@ def main() -> None:
         level=(
             logging.NOTSET
             if args.verbose
-            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+            else logging.DEBUG
+            if len(args.filenames) < 1000
+            else logging.INFO
         ),
         stream=sys.stderr,
     )

--- a/lintrunner_adapters/adapters/pylint_linter.py
+++ b/lintrunner_adapters/adapters/pylint_linter.py
@@ -159,9 +159,11 @@ def check_files(
                 match["message"], match["code"], match["string_code"], show_disable
             ),
             line=int(match["line"]),
-            char=int(match["column"])
-            if match["column"] is not None and not match["column"].startswith("-")
-            else None,
+            char=(
+                int(match["column"])
+                if match["column"] is not None and not match["column"].startswith("-")
+                else None
+            ),
             code=LINTER_CODE,
             severity=SEVERITIES.get(match["code"][0], LintSeverity.ERROR),
             original=None,
@@ -198,11 +200,11 @@ def main() -> None:
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
-        level=logging.NOTSET
-        if args.verbose
-        else logging.DEBUG
-        if len(args.filenames) < 1000
-        else logging.INFO,
+        level=(
+            logging.NOTSET
+            if args.verbose
+            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+        ),
         stream=sys.stderr,
     )
 

--- a/lintrunner_adapters/adapters/pyupgrade_linter.py
+++ b/lintrunner_adapters/adapters/pyupgrade_linter.py
@@ -134,7 +134,9 @@ def main() -> None:
         level=(
             logging.NOTSET
             if args.verbose
-            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+            else logging.DEBUG
+            if len(args.filenames) < 1000
+            else logging.INFO
         ),
         stream=sys.stderr,
     )

--- a/lintrunner_adapters/adapters/pyupgrade_linter.py
+++ b/lintrunner_adapters/adapters/pyupgrade_linter.py
@@ -131,11 +131,11 @@ def main() -> None:
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
-        level=logging.NOTSET
-        if args.verbose
-        else logging.DEBUG
-        if len(args.filenames) < 1000
-        else logging.INFO,
+        level=(
+            logging.NOTSET
+            if args.verbose
+            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+        ),
         stream=sys.stderr,
     )
 

--- a/lintrunner_adapters/adapters/refurb_linter.py
+++ b/lintrunner_adapters/adapters/refurb_linter.py
@@ -98,9 +98,11 @@ def check_files(
                 show_disable,
             ),
             line=int(match["line"]),
-            char=int(match["column"])
-            if match["column"] is not None and not match["column"].startswith("-")
-            else None,
+            char=(
+                int(match["column"])
+                if match["column"] is not None and not match["column"].startswith("-")
+                else None
+            ),
             code=LINTER_CODE,
             severity=severities.get(match["code"], LintSeverity.ADVICE),
             original=None,
@@ -137,11 +139,11 @@ def main() -> None:
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
-        level=logging.NOTSET
-        if args.verbose
-        else logging.DEBUG
-        if len(args.filenames) < 1000
-        else logging.INFO,
+        level=(
+            logging.NOTSET
+            if args.verbose
+            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+        ),
         stream=sys.stderr,
     )
 

--- a/lintrunner_adapters/adapters/refurb_linter.py
+++ b/lintrunner_adapters/adapters/refurb_linter.py
@@ -142,7 +142,9 @@ def main() -> None:
         level=(
             logging.NOTSET
             if args.verbose
-            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+            else logging.DEBUG
+            if len(args.filenames) < 1000
+            else logging.INFO
         ),
         stream=sys.stderr,
     )

--- a/lintrunner_adapters/adapters/requirements_txt_linter.py
+++ b/lintrunner_adapters/adapters/requirements_txt_linter.py
@@ -174,7 +174,9 @@ def main() -> None:
         level=(
             logging.NOTSET
             if args.verbose
-            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+            else logging.DEBUG
+            if len(args.filenames) < 1000
+            else logging.INFO
         ),
         stream=sys.stderr,
     )

--- a/lintrunner_adapters/adapters/requirements_txt_linter.py
+++ b/lintrunner_adapters/adapters/requirements_txt_linter.py
@@ -171,11 +171,11 @@ def main() -> None:
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
-        level=logging.NOTSET
-        if args.verbose
-        else logging.DEBUG
-        if len(args.filenames) < 1000
-        else logging.INFO,
+        level=(
+            logging.NOTSET
+            if args.verbose
+            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+        ),
         stream=sys.stderr,
     )
 

--- a/lintrunner_adapters/adapters/ruff_fix_linter.py
+++ b/lintrunner_adapters/adapters/ruff_fix_linter.py
@@ -113,11 +113,11 @@ def main() -> None:
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
-        level=logging.NOTSET
-        if args.verbose
-        else logging.DEBUG
-        if len(args.filenames) < 1000
-        else logging.INFO,
+        level=(
+            logging.NOTSET
+            if args.verbose
+            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+        ),
         stream=sys.stderr,
     )
 

--- a/lintrunner_adapters/adapters/ruff_fix_linter.py
+++ b/lintrunner_adapters/adapters/ruff_fix_linter.py
@@ -116,7 +116,9 @@ def main() -> None:
         level=(
             logging.NOTSET
             if args.verbose
-            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+            else logging.DEBUG
+            if len(args.filenames) < 1000
+            else logging.INFO
         ),
         stream=sys.stderr,
     )

--- a/lintrunner_adapters/adapters/ruff_format_linter.py
+++ b/lintrunner_adapters/adapters/ruff_format_linter.py
@@ -115,7 +115,9 @@ def main() -> None:
         level=(
             logging.NOTSET
             if args.verbose
-            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+            else logging.DEBUG
+            if len(args.filenames) < 1000
+            else logging.INFO
         ),
         stream=sys.stderr,
     )

--- a/lintrunner_adapters/adapters/ruff_format_linter.py
+++ b/lintrunner_adapters/adapters/ruff_format_linter.py
@@ -112,11 +112,11 @@ def main() -> None:
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
-        level=logging.NOTSET
-        if args.verbose
-        else logging.DEBUG
-        if len(args.filenames) < 1000
-        else logging.INFO,
+        level=(
+            logging.NOTSET
+            if args.verbose
+            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+        ),
         stream=sys.stderr,
     )
 

--- a/lintrunner_adapters/adapters/ruff_linter.py
+++ b/lintrunner_adapters/adapters/ruff_linter.py
@@ -282,11 +282,11 @@ def main() -> None:
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
-        level=logging.NOTSET
-        if args.verbose
-        else logging.DEBUG
-        if len(args.filenames) < 1000
-        else logging.INFO,
+        level=(
+            logging.NOTSET
+            if args.verbose
+            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+        ),
         stream=sys.stderr,
     )
 

--- a/lintrunner_adapters/adapters/ruff_linter.py
+++ b/lintrunner_adapters/adapters/ruff_linter.py
@@ -285,7 +285,9 @@ def main() -> None:
         level=(
             logging.NOTSET
             if args.verbose
-            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+            else logging.DEBUG
+            if len(args.filenames) < 1000
+            else logging.INFO
         ),
         stream=sys.stderr,
     )

--- a/lintrunner_adapters/adapters/rustfmt_linter.py
+++ b/lintrunner_adapters/adapters/rustfmt_linter.py
@@ -190,11 +190,11 @@ def main() -> None:
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
-        level=logging.NOTSET
-        if args.verbose
-        else logging.DEBUG
-        if len(args.filenames) < 1000
-        else logging.INFO,
+        level=(
+            logging.NOTSET
+            if args.verbose
+            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+        ),
         stream=sys.stderr,
     )
 

--- a/lintrunner_adapters/adapters/rustfmt_linter.py
+++ b/lintrunner_adapters/adapters/rustfmt_linter.py
@@ -193,7 +193,9 @@ def main() -> None:
         level=(
             logging.NOTSET
             if args.verbose
-            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+            else logging.DEBUG
+            if len(args.filenames) < 1000
+            else logging.INFO
         ),
         stream=sys.stderr,
     )

--- a/lintrunner_adapters/adapters/toml_sort_linter.py
+++ b/lintrunner_adapters/adapters/toml_sort_linter.py
@@ -112,7 +112,9 @@ def main() -> None:
         level=(
             logging.NOTSET
             if args.verbose
-            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+            else logging.DEBUG
+            if len(args.filenames) < 1000
+            else logging.INFO
         ),
         stream=sys.stderr,
     )

--- a/lintrunner_adapters/adapters/toml_sort_linter.py
+++ b/lintrunner_adapters/adapters/toml_sort_linter.py
@@ -109,11 +109,11 @@ def main() -> None:
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
-        level=logging.NOTSET
-        if args.verbose
-        else logging.DEBUG
-        if len(args.filenames) < 1000
-        else logging.INFO,
+        level=(
+            logging.NOTSET
+            if args.verbose
+            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+        ),
         stream=sys.stderr,
     )
 

--- a/lintrunner_adapters/adapters/ufmt_linter.py
+++ b/lintrunner_adapters/adapters/ufmt_linter.py
@@ -90,11 +90,11 @@ def main() -> None:
 
     logging.basicConfig(
         format="<%(threadName)s:%(levelname)s> %(message)s",
-        level=logging.NOTSET
-        if args.verbose
-        else logging.DEBUG
-        if len(args.filenames) < 1000
-        else logging.INFO,
+        level=(
+            logging.NOTSET
+            if args.verbose
+            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+        ),
         stream=sys.stderr,
     )
 

--- a/lintrunner_adapters/adapters/ufmt_linter.py
+++ b/lintrunner_adapters/adapters/ufmt_linter.py
@@ -93,7 +93,9 @@ def main() -> None:
         level=(
             logging.NOTSET
             if args.verbose
-            else logging.DEBUG if len(args.filenames) < 1000 else logging.INFO
+            else logging.DEBUG
+            if len(args.filenames) < 1000
+            else logging.INFO
         ),
         stream=sys.stderr,
     )

--- a/lintrunner_adapters/tools/convert_to_sarif.py
+++ b/lintrunner_adapters/tools/convert_to_sarif.py
@@ -19,7 +19,7 @@ def severity_to_github_level(severity: str) -> str:
 
 
 def parse_single_lintrunner_result(
-    lintrunner_result: dict[str, Any]
+    lintrunner_result: dict[str, Any],
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     r"""Parse a single lintrunner result.
 


### PR DESCRIPTION
Fixes #93. This change uses `Path().resolve()` on the file path provided to black to avoid a bug described in https://github.com/psf/black/issues/4209.

Thanks @guotuofeng